### PR TITLE
fix: fragment size and offset fixes

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -26,11 +26,7 @@ func (r *Reader) getFragmentDataFromInode(in *inode.Inode) ([]byte, error) {
 		if !bf.Fragmented {
 			return make([]byte, 0), nil
 		}
-		if bf.BlockStart == 0 {
-			size = uint64(bf.Size)
-		} else {
-			size = uint64(bf.BlockSizes[len(bf.BlockSizes)-1])
-		}
+		size = uint64(bf.Size % r.super.BlockSize)
 		fragIndex = bf.FragmentIndex
 		fragOffset = bf.FragmentOffset
 	} else if in.Type == inode.ExtFileType {
@@ -38,11 +34,7 @@ func (r *Reader) getFragmentDataFromInode(in *inode.Inode) ([]byte, error) {
 		if !bf.Fragmented {
 			return make([]byte, 0), nil
 		}
-		if bf.BlockStart == 0 {
-			size = bf.Size
-		} else {
-			size = uint64(bf.BlockSizes[len(bf.BlockSizes)-1])
-		}
+		size = bf.Size % uint64(r.super.BlockSize)
 		fragIndex = bf.FragmentIndex
 		fragOffset = bf.FragmentOffset
 	} else {
@@ -53,7 +45,7 @@ func (r *Reader) getFragmentDataFromInode(in *inode.Inode) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = fragEntryRdr.Seek(int64(16*fragIndex), io.SeekStart)
+	_, err = fragEntryRdr.Seek(int64((16*fragIndex)%8192), io.SeekStart)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/inode/inodetypes.go
+++ b/internal/inode/inodetypes.go
@@ -130,7 +130,7 @@ func NewFile(rdr io.Reader, blockSize uint32) (File, error) {
 	}
 	inode.Fragmented = inode.FragmentIndex != 0xFFFFFFFF
 	blocks := inode.Size / blockSize
-	if inode.Size%blockSize > 0 {
+	if !inode.Fragmented && inode.Size%blockSize > 0 {
 		blocks++
 	}
 	inode.BlockSizes = make([]uint32, blocks, blocks)
@@ -165,7 +165,7 @@ func NewExtendedFile(rdr io.Reader, blockSize uint32) (ExtFile, error) {
 	}
 	inode.Fragmented = inode.FragmentIndex != 0xFFFFFFFF
 	blocks := inode.Size / uint64(blockSize)
-	if inode.Size%uint64(blockSize) > 0 {
+	if !inode.Fragmented && inode.Size%uint64(blockSize) > 0 {
 		blocks++
 	}
 	inode.BlockSizes = make([]uint32, blocks, blocks)


### PR DESCRIPTION
This patch set was developed against the latest version of the module (v0.5.4). I see that there are substantial changes on `main` which are not yet tagged. I haven't targeted those yet in the interest of finding a fix for the version that's actively in use. @CalebQ42 happy to help investigate to see if the same issue is present in `main` and develop a fix there if so, or assist in any other way you see fit. Thank you!

Here are the underlying causes of #14, as I understand it...

The first is that the code reads one too many `blocks` when a basic or extended file inode contains a frag index here:

https://github.com/CalebQ42/squashfs/blob/0a2ced9072fc028a298e05bc894a73a9dff5ba52/internal/inode/inodetypes.go#L132-L137

When a fragment is present, the last value in `blocks` ends up containing the first four bytes of the next inode.

The second issue is that this last value of `blocks` ends up being used to calculate the uncompressed size of the fragment when `bf.BlockStart != 0`:

https://github.com/CalebQ42/squashfs/blob/0a2ced9072fc028a298e05bc894a73a9dff5ba52/fragment.go#L29-L33

This results in a bogus fragment `size` when `bf.BlockStart != 0`.

Finally, when reading the fragment entry, I believe there's a math error when `Seek`ing within the fragment table here:

https://github.com/CalebQ42/squashfs/blob/0a2ced9072fc028a298e05bc894a73a9dff5ba52/fragment.go#L52-L59

I believe the offset passed to `Seek` needs to be modulo the metadata block size (8k)?

Fixes #14 