### PR TITLE
fix: use correct ENODATA value on different platforms

### DIFF
--- a/fuse2.go
+++ b/fuse2.go
@@ -100,7 +100,7 @@ func (f fileNode2) ReadAll(ctx context.Context) ([]byte, error) {
 		_, err := f.WriteTo(&buf)
 		return buf.Bytes(), err
 	}
-	return nil, fuse.ENODATA
+	return nil, ENODATA
 }
 
 func (f fileNode2) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
@@ -112,7 +112,7 @@ func (f fileNode2) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.R
 		}
 		return nil
 	}
-	return fuse.ENODATA
+	return ENODATA
 }
 
 func (f fileNode2) ReadDirAll(ctx context.Context) (out []fuse.Dirent, err error) {

--- a/fuse3.go
+++ b/fuse3.go
@@ -98,7 +98,7 @@ func (f fileNode) ReadAll(ctx context.Context) ([]byte, error) {
 		_, err := f.WriteTo(&buf)
 		return buf.Bytes(), err
 	}
-	return nil, fuse.ENODATA
+	return nil, ENODATA
 }
 
 func (f fileNode) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
@@ -110,7 +110,7 @@ func (f fileNode) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.Re
 		}
 		return nil
 	}
-	return fuse.ENODATA
+	return ENODATA
 }
 
 func (f fileNode) ReadDirAll(ctx context.Context) (out []fuse.Dirent, err error) {

--- a/fuse_darwin.go
+++ b/fuse_darwin.go
@@ -1,5 +1,3 @@
-//go:build !linux
-
 package squashfs
 
 import (

--- a/fuse_darwin.go
+++ b/fuse_darwin.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package squashfs
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+var ENODATA = unix.Errno(unix.ENODATA)

--- a/fuse_linux.go
+++ b/fuse_linux.go
@@ -1,0 +1,3 @@
+package squashfs
+
+var ENODATA = fuse.ENODATA

--- a/fuse_windows.go
+++ b/fuse_windows.go
@@ -1,0 +1,3 @@
+package squashfs
+
+var ENODATA = windows.Errno(windows.ENODATA)

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,5 @@ require (
 
 require (
 	github.com/seaweedfs/fuse v1.2.2
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,5 @@ github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Uses `unix.ENODATA` for Darwin and `windows.ENODATA` for windows.

Fixes #19 