### PR TITLE
Allow mounting with an offset

### DIFF
--- a/cmd/go-unsquashfs/main.go
+++ b/cmd/go-unsquashfs/main.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	verbose := flag.Bool("v", false, "Verbose")
+	offset := flag.Int64("o", 0, "Offset")
 	ignore := flag.Bool("ip", false, "Ignore Permissions and extract all files/folders with 0755")
 	flag.Parse()
 	if len(flag.Args()) < 2 {
@@ -21,7 +22,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	r, err := squashfs.NewReader(f)
+	r, err := squashfs.NewReaderAtOffset(f, *offset)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When mounting squashfs images embedded in apptainer image,
using offset means we don't need to use a temporary copy.

Example of such usage, with regular `unsquashfs`:
https://github.com/afbjorklund/unsingularity