### PR TITLE
Add list option to unsquashfs

### DIFF
--- a/cmd/go-unsquashfs/main.go
+++ b/cmd/go-unsquashfs/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/CalebQ42/squashfs"
@@ -11,6 +13,7 @@ import (
 
 func main() {
 	verbose := flag.Bool("v", false, "Verbose")
+	list := flag.Bool("l", false, "List")
 	ignore := flag.Bool("ip", false, "Ignore Permissions and extract all files/folders with 0755")
 	flag.Parse()
 	if len(flag.Args()) < 2 {
@@ -24,6 +27,17 @@ func main() {
 	r, err := squashfs.NewReader(f)
 	if err != nil {
 		panic(err)
+	}
+	if *list {
+		root := flag.Arg(1)
+		fs.WalkDir(r, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(filepath.Join(root, path))
+			return nil
+		})
+		return
 	}
 	op := squashfs.DefaultOptions()
 	op.Verbose = *verbose

--- a/cmd/go-unsquashfs/main.go
+++ b/cmd/go-unsquashfs/main.go
@@ -6,14 +6,33 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/CalebQ42/squashfs"
 )
 
+func printEntry(root, path string, d fs.DirEntry) {
+	fi, _ := d.Info()
+	sfi := fi.(squashfs.FileInfo)
+	owner := fmt.Sprintf("%d/%d",
+		sfi.Uid(),
+		sfi.Gid())
+	link := ""
+	if sfi.IsSymlink() {
+		link = " -> " + sfi.SymlinkPath()
+	}
+	fmt.Printf("%s %s %*d %s %s%s\n",
+		strings.ToLower(fi.Mode().String()),
+		owner, 26-len(owner), fi.Size(),
+		fi.ModTime().Format("2006-01-02 15:04"),
+		filepath.Join(root, path), link)
+}
+
 func main() {
 	verbose := flag.Bool("v", false, "Verbose")
 	list := flag.Bool("l", false, "List")
+	long := flag.Bool("ll", false, "List with attributes")
 	ignore := flag.Bool("ip", false, "Ignore Permissions and extract all files/folders with 0755")
 	flag.Parse()
 	if len(flag.Args()) < 2 {
@@ -28,13 +47,17 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if *list {
+	if *list || *long {
 		root := flag.Arg(1)
 		fs.WalkDir(r, ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				panic(err)
 			}
-			fmt.Println(filepath.Join(root, path))
+			if *long {
+				printEntry(root, path, d)
+			} else {
+				fmt.Println(filepath.Join(root, path))
+			}
 			return nil
 		})
 		return

--- a/file.go
+++ b/file.go
@@ -127,7 +127,7 @@ func (f *File) ReadDir(n int) ([]fs.DirEntry, error) {
 		}
 	}
 	var out []fs.DirEntry
-	var fi fileInfo
+	var fi FileInfo
 	for _, e := range d.Entries[start:end] {
 		fi, err = f.r.newFileInfo(e)
 		if err != nil {

--- a/file.go
+++ b/file.go
@@ -142,7 +142,15 @@ func (f *File) ReadDir(n int) ([]fs.DirEntry, error) {
 
 // Returns the file's fs.FileInfo
 func (f *File) Stat() (fs.FileInfo, error) {
-	return newFileInfo(f.b.Name, &f.b.Inode), nil
+	uid, err := f.b.Uid(&f.r.Low)
+	if err != nil {
+		return nil, err
+	}
+	gid, err := f.b.Gid(&f.r.Low)
+	if err != nil {
+		return nil, err
+	}
+	return newFileInfo(f.b.Name, uid, gid, &f.b.Inode), nil
 }
 
 // SymlinkPath returns the symlink's target path. Is the File isn't a symlink, returns an empty string.

--- a/file_info.go
+++ b/file_info.go
@@ -8,7 +8,7 @@ import (
 	"github.com/CalebQ42/squashfs/low/inode"
 )
 
-type fileInfo struct {
+type FileInfo struct {
 	name     string
 	size     int64
 	perm     uint32
@@ -16,15 +16,15 @@ type fileInfo struct {
 	fileType uint16
 }
 
-func (r Reader) newFileInfo(e directory.Entry) (fileInfo, error) {
+func (r Reader) newFileInfo(e directory.Entry) (FileInfo, error) {
 	i, err := r.Low.InodeFromEntry(e)
 	if err != nil {
-		return fileInfo{}, err
+		return FileInfo{}, err
 	}
 	return newFileInfo(e.Name, &i), nil
 }
 
-func newFileInfo(name string, i *inode.Inode) fileInfo {
+func newFileInfo(name string, i *inode.Inode) FileInfo {
 	var size int64
 	switch i.Type {
 	case inode.Fil:
@@ -32,7 +32,7 @@ func newFileInfo(name string, i *inode.Inode) fileInfo {
 	case inode.EFil:
 		size = int64(i.Data.(inode.EFile).Size)
 	}
-	return fileInfo{
+	return FileInfo{
 		name:     name,
 		size:     size,
 		perm:     uint32(i.Perm),
@@ -41,15 +41,15 @@ func newFileInfo(name string, i *inode.Inode) fileInfo {
 	}
 }
 
-func (f fileInfo) Name() string {
+func (f FileInfo) Name() string {
 	return f.name
 }
 
-func (f fileInfo) Size() int64 {
+func (f FileInfo) Size() int64 {
 	return f.size
 }
 
-func (f fileInfo) Mode() fs.FileMode {
+func (f FileInfo) Mode() fs.FileMode {
 	switch f.fileType {
 	case inode.Dir, inode.EDir:
 		return fs.FileMode(f.perm | uint32(fs.ModeDir))
@@ -65,31 +65,31 @@ func (f fileInfo) Mode() fs.FileMode {
 	return fs.FileMode(f.perm)
 }
 
-func (f fileInfo) ModTime() time.Time {
+func (f FileInfo) ModTime() time.Time {
 	return time.Unix(int64(f.modTime), 0)
 }
 
-func (f fileInfo) IsDir() bool {
+func (f FileInfo) IsDir() bool {
 	return f.fileType == inode.Dir || f.fileType == inode.EDir
 }
 
-func (f fileInfo) IsSymlink() bool {
+func (f FileInfo) IsSymlink() bool {
 	return f.fileType == inode.Sym || f.fileType == inode.ESym
 }
 
-func (f fileInfo) IsDevice() bool {
+func (f FileInfo) IsDevice() bool {
 	return f.fileType == inode.Block || f.fileType == inode.EBlock ||
 		f.fileType == inode.Char || f.fileType == inode.EChar
 }
 
-func (f fileInfo) IsFifo() bool {
+func (f FileInfo) IsFifo() bool {
 	return f.fileType == inode.Fifo || f.fileType == inode.EFifo
 }
 
-func (f fileInfo) IsSocket() bool {
+func (f FileInfo) IsSocket() bool {
 	return f.fileType == inode.Sock || f.fileType == inode.ESock
 }
 
-func (f fileInfo) Sys() any {
+func (f FileInfo) Sys() any {
 	return nil
 }

--- a/file_info.go
+++ b/file_info.go
@@ -11,6 +11,7 @@ import (
 type FileInfo struct {
 	name     string
 	size     int64
+	target   string
 	perm     uint32
 	modTime  uint32
 	fileType uint16
@@ -26,15 +27,21 @@ func (r Reader) newFileInfo(e directory.Entry) (FileInfo, error) {
 
 func newFileInfo(name string, i *inode.Inode) FileInfo {
 	var size int64
+	var target string
 	switch i.Type {
 	case inode.Fil:
 		size = int64(i.Data.(inode.File).Size)
 	case inode.EFil:
 		size = int64(i.Data.(inode.EFile).Size)
+	case inode.Sym:
+		target = string(i.Data.(inode.Symlink).Target)
+	case inode.ESym:
+		target = string(i.Data.(inode.ESymlink).Target)
 	}
 	return FileInfo{
 		name:     name,
 		size:     size,
+		target:   target,
 		perm:     uint32(i.Perm),
 		modTime:  i.ModTime,
 		fileType: i.Type,
@@ -47,6 +54,10 @@ func (f FileInfo) Name() string {
 
 func (f FileInfo) Size() int64 {
 	return f.size
+}
+
+func (f FileInfo) SymlinkPath() string {
+	return f.target
 }
 
 func (f FileInfo) Mode() fs.FileMode {


### PR DESCRIPTION
Add the `unsquashfs` options for listing without extracting:

```
	-l[s]			list filesystem, but do not extract files
	-ll[s]			list filesystem with file attributes (like
				ls -l output), but do not extract files
	-lln[umeric]		same as -lls but with numeric uids and gids
```

This requires extending the `FileInfo` with some handy extras...

Then user can choose between `fs.FileInfo` and `squashfs.FileInfo`