### PR TITLE
Allow disabling lzo and lzma

### DIFF
--- a/internal/decompress/lzma.go
+++ b/internal/decompress/lzma.go
@@ -1,3 +1,4 @@
+//go:build !no_lzma
 package decompress
 
 import (

--- a/internal/decompress/lzma_none.go
+++ b/internal/decompress/lzma_none.go
@@ -1,0 +1,12 @@
+//go:build no_lzma
+package decompress
+
+import (
+	"fmt"
+)
+
+type Lzma struct{}
+
+func (l Lzma) Decompress(_ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("lzma is not supported")
+}

--- a/internal/decompress/lzo.go
+++ b/internal/decompress/lzo.go
@@ -1,3 +1,4 @@
+//go:build !no_lzo
 package decompress
 
 import (

--- a/internal/decompress/lzo_none.go
+++ b/internal/decompress/lzo_none.go
@@ -1,0 +1,12 @@
+//go:build no_lzo
+package decompress
+
+import (
+	"fmt"
+)
+
+type Lzo struct{}
+
+func (l Lzo) Decompress(_ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("lzo is not supported")
+}


### PR DESCRIPTION
By setting the buildtags "no_lzo" and/or "no_lzma", one can drop the library dependency on lzo and lzma.

The same could be done for xz as well, but there are still lots of archives using xz compression out there.

Closes #36

Note: squashfs-tools uses `zstd -15` by default, which offers the same kind of compression ratio as `xz`