### PR TITLE
Add support for hardlinks through FileInfo Inode number

### DIFF
--- a/cmd/go-unsquashfs/main.go
+++ b/cmd/go-unsquashfs/main.go
@@ -36,6 +36,9 @@ func groupName(gid int, numeric bool) string {
 	return gs
 }
 
+// lookup path from inode num
+var lookup = map[uint]string{}
+
 func printEntry(root, path string, d fs.DirEntry, numeric bool) {
 	fi, _ := d.Info()
 	sfi := fi.(squashfs.FileInfo)
@@ -46,9 +49,18 @@ func printEntry(root, path string, d fs.DirEntry, numeric bool) {
 	if sfi.IsSymlink() {
 		link = " -> " + sfi.SymlinkPath()
 	}
+	size := fi.Size()
+	inode := sfi.Inode()
+	if p, ok := lookup[inode]; ok {
+		link = " link to " + filepath.Join(root, p)
+		size = 0
+	} else {
+		// insert first
+		lookup[inode] = path
+	}
 	fmt.Printf("%s %s %*d %s %s%s\n",
 		strings.ToLower(fi.Mode().String()),
-		owner, 26-len(owner), fi.Size(),
+		owner, 26-len(owner), size,
 		fi.ModTime().Format("2006-01-02 15:04"),
 		filepath.Join(root, path), link)
 }

--- a/file_info.go
+++ b/file_info.go
@@ -17,6 +17,7 @@ type FileInfo struct {
 	perm     uint32
 	modTime  uint32
 	fileType uint16
+	inodeNum uint32
 }
 
 func (r Reader) newFileInfo(e directory.Entry) (FileInfo, error) {
@@ -57,6 +58,7 @@ func newFileInfo(name string, uid, gid uint32, i *inode.Inode) FileInfo {
 		perm:     uint32(i.Perm),
 		modTime:  i.ModTime,
 		fileType: i.Type,
+		inodeNum: i.Num,
 	}
 }
 
@@ -78,6 +80,10 @@ func (f FileInfo) Size() int64 {
 
 func (f FileInfo) SymlinkPath() string {
 	return f.target
+}
+
+func (f FileInfo) Inode() uint {
+	return uint(f.inodeNum)
 }
 
 func (f FileInfo) Mode() fs.FileMode {


### PR DESCRIPTION
I was wondering why my "busybox" container was so big with squashfs, when compared to tar layers.

But it was due to the hardlinks being counted multiple times, instead of just the first time (per inode)...

BEFORE

```
drwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/[
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/[[
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/acpid
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/add-shell
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/addgroup
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/adduser
```

AFTER

```
drwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin
-rwxr-xr-x root/root           1029688 2024-09-26 23:31 squashfs-root/bin/[
-rwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin/[[ link to squashfs-root/bin/[
-rwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin/acpid link to squashfs-root/bin/[
-rwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin/add-shell link to squashfs-root/bin/[
-rwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin/addgroup link to squashfs-root/bin/[
-rwxr-xr-x root/root                 0 2024-09-26 23:31 squashfs-root/bin/adduser link to squashfs-root/bin/[
```

All the links was actually made from the `busybox` binary, but here it just reports the first.

The output format was made to look the same as tar's, so that it is easier to compare...

----

Regular `unsquashfs` would say:

`created 34 files`
`created 27 directories`
`created 8 symlinks`
`created 0 devices`
`created 0 fifos`
`created 0 sockets`
`created 404 hardlinks`

From `docker://busybox:latest`

Converted into `busybox_latest.sif`