### PR TITLE
go-unsquashfs hardlinks & squashfslow access

### DIFF
--- a/cmd/go-unsquashfs/main.go
+++ b/cmd/go-unsquashfs/main.go
@@ -45,13 +45,19 @@ func printFile(rdr *squashfs.Reader, path string, f *squashfs.File) {
 	owner := fmt.Sprintf("%s/%s",
 		userName(sfi.Uid(), *numeric),
 		groupName(sfi.Gid(), *numeric))
-	link, isHardLink := hardLinks[f.Low.Inode.Num]
+	var link string
+	var isHardLink bool
+	if *showHardLinks {
+		link, isHardLink = hardLinks[f.Low.Inode.Num]
+		if !isHardLink {
+			hardLinks[f.Low.Inode.Num] = path
+		}
+	}
 	var size int64
 	if isHardLink {
 		size = 0
 	} else {
 		size = fi.Size()
-		hardLinks[f.Low.Inode.Num] = path
 	}
 	if sfi.IsSymlink() {
 		link = " -> " + sfi.SymlinkPath()

--- a/fs.go
+++ b/fs.go
@@ -91,6 +91,10 @@ func (f *FS) Glob(pattern string) (out []string, err error) {
 
 // Opens the file at name. Returns a *File as an fs.File.
 func (f FS) Open(name string) (fs.File, error) {
+	return f.OpenFile(name)
+}
+
+func (f FS) OpenFile(name string) (*File, error) {
 	name = filepath.Clean(name)
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{
@@ -111,7 +115,7 @@ func (f FS) Open(name string) (fs.File, error) {
 				Err:  fs.ErrNotExist,
 			}
 		} else {
-			return f.parent.Open(strings.Join(split[1:], "/"))
+			return f.parent.OpenFile(strings.Join(split[1:], "/"))
 		}
 	}
 	i, found := slices.BinarySearchFunc(f.d.Entries, split[0], func(e directory.Entry, name string) int {
@@ -146,7 +150,7 @@ func (f FS) Open(name string) (fs.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f.r.FSFromDirectory(d, f).Open(strings.Join(split[1:], "/"))
+	return f.r.FSFromDirectory(d, f).OpenFile(strings.Join(split[1:], "/"))
 }
 
 // Returns all DirEntry's for the directory at name.

--- a/fs.go
+++ b/fs.go
@@ -17,13 +17,13 @@ import (
 type FS struct {
 	r      *Reader
 	parent *FS
-	d      squashfslow.Directory
+	LowDir squashfslow.Directory
 }
 
 // Creates a new *FS from the given squashfs.directory
 func (r *Reader) FSFromDirectory(d squashfslow.Directory, parent FS) FS {
 	return FS{
-		d:      d,
+		LowDir: d,
 		r:      r,
 		parent: &parent,
 	}
@@ -42,10 +42,10 @@ func (f *FS) Glob(pattern string) (out []string, err error) {
 		}
 	}
 	split := strings.Split(pattern, "/")
-	for i := range f.d.Entries {
-		if match, _ := path.Match(split[0], f.d.Entries[i].Name); match {
+	for i := range f.LowDir.Entries {
+		if match, _ := path.Match(split[0], f.LowDir.Entries[i].Name); match {
 			if len(split) == 1 {
-				out = append(out, f.d.Entries[i].Name)
+				out = append(out, f.LowDir.Entries[i].Name)
 				continue
 			}
 			sub, err := f.Sub(split[0])
@@ -81,7 +81,7 @@ func (f *FS) Glob(pattern string) (out []string, err error) {
 				}
 			}
 			for i := range subGlob {
-				subGlob[i] = f.d.Name + "/" + subGlob[i]
+				subGlob[i] = f.LowDir.Name + "/" + subGlob[i]
 			}
 			out = append(out, subGlob...)
 		}
@@ -118,7 +118,7 @@ func (f FS) OpenFile(name string) (*File, error) {
 			return f.parent.OpenFile(strings.Join(split[1:], "/"))
 		}
 	}
-	i, found := slices.BinarySearchFunc(f.d.Entries, split[0], func(e directory.Entry, name string) int {
+	i, found := slices.BinarySearchFunc(f.LowDir.Entries, split[0], func(e directory.Entry, name string) int {
 		return strings.Compare(e.Name, name)
 	})
 	if !found {
@@ -128,13 +128,13 @@ func (f FS) OpenFile(name string) (*File, error) {
 			Err:  fs.ErrNotExist,
 		}
 	}
-	b, err := f.r.Low.BaseFromEntry(f.d.Entries[i])
+	b, err := f.r.Low.BaseFromEntry(f.LowDir.Entries[i])
 	if err != nil {
 		return nil, err
 	}
 	if len(split) == 1 {
 		return &File{
-			b:      b,
+			Low:    b,
 			r:      f.r,
 			parent: f,
 		}, nil
@@ -260,20 +260,20 @@ func (f FS) ExtractWithOptions(folder string, op *ExtractionOptions) error {
 func (f FS) File() *File {
 	if f.parent != nil {
 		return &File{
-			b:      f.d.FileBase,
+			Low:    f.LowDir.FileBase,
 			parent: *f.parent,
 			r:      f.r,
 		}
 	}
 	return &File{
-		b: f.d.FileBase,
-		r: f.r,
+		Low: f.LowDir.FileBase,
+		r:   f.r,
 	}
 }
 
 func (f FS) path() string {
 	if f.parent == nil {
-		return f.d.Name
+		return f.LowDir.Name
 	}
-	return filepath.Join(f.parent.path(), f.d.Name)
+	return filepath.Join(f.parent.path(), f.LowDir.Name)
 }

--- a/reader.go
+++ b/reader.go
@@ -22,8 +22,8 @@ func NewReader(r io.ReaderAt) (Reader, error) {
 		Low: rdr,
 	}
 	out.FS = FS{
-		d: rdr.Root,
-		r: &out,
+		LowDir: rdr.Root,
+		r:   &out,
 	}
 	return out, nil
 }


### PR DESCRIPTION
* Add `-show-hard-links` to show hard links in `go-unsquashfs`, similar to the implementation in #38.
* Added `-e` to choose a single file or directory to extract or list in `go-unsquashfs`.
* `go-unsquashfs` list options no longer require a second argument.
* Added access to `squashfslow` values in `File` and `FS` structs.