### PR TITLE
[PATCH] Change xz module due to licensing concerns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	github.com/klauspost/compress v1.18.0
+	github.com/mikelolasagasti/xz v1.0.1
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e
-	github.com/therootcompany/xz v1.0.1
 	github.com/ulikunitz/xz v0.5.12
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/mikelolasagasti/xz v1.0.1 h1:Q2F2jX0RYJUG3+WsM+FJknv+6eVjsjXNDV0KJXZzkD0=
+github.com/mikelolasagasti/xz v1.0.1/go.mod h1:muAirjiOUxPRXwm9HdDtB3uoRPrGnL85XHtokL9Hcgc=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e h1:dCWirM5F3wMY+cmRda/B1BiPsFtmzXqV9b0hLWtVBMs=
 github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e/go.mod h1:9leZcVcItj6m9/CfHY5Em/iBrCz7js8LcRQGTKEEv2M=
-github.com/therootcompany/xz v1.0.1 h1:CmOtsn1CbtmyYiusbfmhmkpAAETj0wBIH6kCYaX+xzw=
-github.com/therootcompany/xz v1.0.1/go.mod h1:3K3UH1yCKgBneZYhuQUvJ9HPD19UEXEI0BWbMn8qNMY=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/internal/decompress/xz.go
+++ b/internal/decompress/xz.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/therootcompany/xz"
+	"github.com/mikelolasagasti/xz"
 )
 
 type Xz struct {


### PR DESCRIPTION
The original module `github.com/xi2/xz/` is in the Public Domain but does not explicitly specify a license. The module has not been updated since 2017.

The fork at `github.com/therootcompany/xz` simply adds a Creative Commons CC0 1.0 Universal (CC0-1.0) license declaration for Public Domain use. However, this license has been disallowed by Fedora since 2022, as announced in the [Fedora Legal thread](https://lists.fedoraproject.org/archives/list/legal@lists.fedoraproject.org/thread/RRYM3CLYJYW64VSQIXY6IF3TCDZGS6LM/#EO4JUQRG4GDLRHJHJBUZDR2RHMXNU5HT), and the restriction also applies to RHEL and related distributions.

The module at `github.com/mikelolasagasti/xz` is a fork of `xi2/xz`, but declares the BSD Zero Clause License (0BSD) instead. This aligns with the licensing of the upstream source from which `xi2/xz` originally derives, which has moved from [Public Domain to 0BSD for recent updates](https://tukaani.org/xz/embedded.html#_licensing).